### PR TITLE
Clear cache improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This extension adds a maildir summary in `mu4e-main-view`.
 
 It gets the list of maildirs and runs a `mu` command for each maildir to count unread and total mails.
 
-To minimize performance issues this information is _cached_ until the index is changed (using `mu4e-index-updated-hook`) and its not rebuilt until `mu4e-main-view` is called (or if `mu4e-main-view` is `current-buffer`). Also, the cache can be updated by pressing `u` in `mu4e-main-view` or updating the index with `U`.
+To minimize performance issues this information is _cached_ until the index is changed (using `mu4e-index-updated-hook`) and its not rebuilt until `mu4e-main-view` is called (or if `mu4e-main-view` buffer is visible). The following key-bindings are added in `mu4e-main-view`:
+- `u` Update the index
+- `C-u u` only clear the cache
+- `C-u C-u u` clear the cache and refresh.
 
 ![Screenshot](https://drive.google.com/uc?export=view&id=0Byv-S6nIE7oRVm85UGVxY3FqMUE)
 
@@ -43,7 +46,7 @@ Pop3 configurations usually have `{cur,new,tmp}` directly in `account1/` but you
 
 ## M-x customize
 
-If the extension has been loaded, simply call `M-x customize-group` and type `mu4e-maildirs-extension`.  Here are a few of the more common customizations. 
+If the extension has been loaded, simply call `M-x customize-group` and type `mu4e-maildirs-extension`.  Here are a few of the more common customizations.
 
 ### Title
 
@@ -56,7 +59,7 @@ The variable `mu4e-maildirs-extension-insert-before-str` is used to control wher
 
 ### Separators
 
-The left separators `»` and `|` can be changed with `mu4e-maildirs-extension-maildir-separator` and `mu4e-maildirs-extension-submaildir-separator` respectively. 
+The left separators `»` and `|` can be changed with `mu4e-maildirs-extension-maildir-separator` and `mu4e-maildirs-extension-submaildir-separator` respectively.
 
 ### Indent
 
@@ -95,3 +98,15 @@ The default format `| maildir_name (unread/total)` can be customized providing y
 ```
 
 Then set `mu4e-maildirs-extension-propertize-func` to `my/mu4e-maildirs-extension-propertize-unread-only` in the `customize-group` area.
+
+## Update index outside emacs
+
+If you update the index outside emacs (by calling `mu` directly) you will need to update the `mu4e-main-view` using `C-u C-u u` or calling `(mu4e-maildirs-extension-force-update '(16))`
+
+
+## Changelog
+
+Short summary of changes
+
+- Auto-update `mu4e-main-view` if the index have changed and the buffer is visible.
+- Use universal argument to be able to manually clear the cache and refresh (`C-u u` and `C-u C-u u`)

--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -288,11 +288,20 @@ clicked."
         (setq mu4e-maildirs-extension-end-point (point))
         (goto-char (point-min))))))
 
-(defun mu4e-maildirs-extension-force-update ()
-  "Clear cache and insert maildirs summary."
-  (interactive)
-  (mu4e-message "Updating index & cache...")
-  (mu4e-update-index))
+(defun mu4e-maildirs-extension-force-update (&optional universal-arg)
+  "Force update cache and summary.
+Default behaviour calls `mu4e-update-index' and update cache/summary if needed.
+When preceded with `universal-argument':
+4 = clears the cache,
+16 = clears the cache and update the summary."
+  (interactive "P")
+  (cond ((equal universal-arg nil)
+         (mu4e-update-index))
+        ((equal universal-arg '(4))
+         (setq mu4e-maildirs-extension-cached-maildirs-data nil))
+        ((equal universal-arg '(16))
+         (setq mu4e-maildirs-extension-cached-maildirs-data nil)
+         (mu4e-maildirs-extension-update))))
 
 ;;;###autoload
 (defun mu4e-maildirs-extension ()

--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -124,9 +124,10 @@ Default dispays as '| maildir_name (unread/total)'."
 
 (defun mu4e-maildirs-extension-index-updated-handler ()
   "Handler for `mu4e-index-updated-hook'."
-  (setq mu4e-maildirs-extension-cached-maildirs-data nil)
-  (when (equal (buffer-name) mu4e-maildirs-extension-buffer-name)
-    (mu4e-maildirs-extension-update)))
+  (let ((arg (if (get-buffer-window mu4e-maildirs-extension-buffer-name)
+                 '(16)
+               '(4))))
+    (mu4e-maildirs-extension-force-update arg)))
 
 (defun mu4e-maildirs-extension-main-view-handler ()
   "Handler for `mu4e-main-view-mode-hook'."


### PR DESCRIPTION
Allow to clear the cache manually using universal argument `C-u u` or force refresh view with `C-u C-u u`. Also via elisp calling `mu4e-maildirs-extension-force-update` function.