### PR TITLE
Use mu4e-msg-changed-hook if available

### DIFF
--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -756,13 +756,17 @@ When preceded with `universal-argument':
 (defun mu4e-maildirs-extension-load ()
   "Initialize."
   (mu4e-maildirs-extension-unload)
-  (add-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func)
+  (if (boundp 'mu4e-msg-changed-hook)
+      (add-hook 'mu4e-msg-changed-hook mu4e-maildirs-extension-index-updated-func)
+  (add-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func))
   (add-hook 'mu4e-main-mode-hook mu4e-maildirs-extension-main-view-func))
 
 ;;;###autoload
 (defun mu4e-maildirs-extension-unload ()
   "Initialize."
-  (remove-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func)
+  (if (boundp 'mu4e-msg-changed-hook)
+      (remove-hook 'mu4e-msg-changed-hook mu4e-maildirs-extension-index-updated-func)
+    (remove-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func))
   (remove-hook 'mu4e-main-mode-hook mu4e-maildirs-extension-main-view-func))
 
 ;;;###autoload


### PR DESCRIPTION
Hi, I have added a new hook for mu4e `mu4e-msg-changed-hook` (https://github.com/djcb/mu/pull/912) to cover more situations including read/remove messages.