### PR TITLE
Add ability to hide maildirs with no unread emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,17 +186,21 @@ Max parallel processes.
 ### mu4e-maildirs-extension-propertize-bm-func
 
 The function to format the bookmark info.
-Default dispays as ' (unread/total)'.
+Default displays as ' (unread/total)'.
 
 ### mu4e-maildirs-extension-propertize-func
 
 The function to format the maildir info.
-Default dispays as '| maildir_name (unread/total)'.
+Default displays as '| maildir_name (unread/total)'.
 
 ### mu4e-maildirs-extension-title
 
 The title for the maildirs extension section.
 If set to `nil' it won't be displayed.
+
+### mu4e-maildirs-extension-hide-empty-maildirs
+
+If non-nil, hide maildirs that do not contain new mail.
 
 ### mu4e-maildirs-extension-toggle-maildir-key
 

--- a/mu4e-maildirs-extension-test.el
+++ b/mu4e-maildirs-extension-test.el
@@ -2,7 +2,7 @@
 
 ;; This file is not part of Emacs
 
-;; Copyright (C) 2015 Andreu Gil Pàmies
+;; Copyright (C) 2015--2017 Andreu Gil Pàmies
 
 ;; Filename: mu4e-maildirs-extension-test.el
 ;; Version: 0.1
@@ -318,6 +318,44 @@ Each subdirectory is not a valid submaildir but a dir containing submaildirs."
                                             mu4e-maildirs-extension-maildirs))
          (prefix (mu4e-maildirs-extension-update-maildir-prefix m)))
     (should (equal prefix mu4e-maildirs-extension-maildir-default-prefix))))
+
+(ert-deftest mu4e-maildirs-extension-run-when-unread/default ()
+  "Tests default when option mu4e-maildirs-extension-hide-empty-maildirs not set."
+  (let* ((path-list '("/account1/*" "/account1/inbox"))
+         (mu4e-maildirs-extension-maildirs
+          (mapcar (lambda(path)
+                    (mu4e-maildirs-extension-new-maildir path))
+                  path-list))
+         (m (mu4e-maildirs-extension-member "/account1/*"
+                                            mu4e-maildirs-extension-maildirs))
+         (prefix nil))
+    (setq mu4e-maildirs-extension-hide-empty-maildirs nil)
+    (should (equal (or (mu4e-maildirs-extension-run-when-unread
+                        m '(lambda (x) 1) nil)
+                       0)
+                   1))))
+
+
+(ert-deftest mu4e-maildirs-extension-run-when-unread/option-set ()
+  "Tests default when option mu4e-maildirs-extension-hide-empty-maildirs not set."
+  (let* ((path-list '("/account1/*" "/account1/inbox"))
+         (mu4e-maildirs-extension-maildirs
+          (mapcar (lambda(path)
+                    (mu4e-maildirs-extension-new-maildir path))
+                  path-list))
+         (m (mu4e-maildirs-extension-member "/account1/*"
+                                            mu4e-maildirs-extension-maildirs))
+         (prefix nil))
+    (setq mu4e-maildirs-extension-hide-empty-maildirs t)
+    (should (equal (or (mu4e-maildirs-extension-run-when-unread
+                        m '(lambda (x) 1) nil)
+                       0)
+                   0))
+  (setq m (plist-put m :unread 1))
+      (should (equal (or (mu4e-maildirs-extension-run-when-unread
+                        m '(lambda (x) 1) nil)
+                       0)
+                   1))))
 
 (provide 'mu4e-maildirs-extension-test)
 ;;; mu4e-maildirs-extension-test.el ends here


### PR DESCRIPTION
Some of my email accounts have a large number of folders, and this PR comes in handy to hide the ones that contain no new emails.

This is done by introducing a new option, `mu4e-maildirs-extension-hide-empty-maildirs` set to `nil` by default (old behaviour).  When the option is set to `t`, the maildir is not inserted if it doesn't contain new emails.
 
This requires to also change one of the existing `mu4e-maildirs-extension-after-insert-maildir-hook` option value to ensure the following newline is also conditionally inserted.