### PR TITLE
Use `mu4e-message-changed-hook` hook.

### DIFF
--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -788,16 +788,16 @@ When preceded with `universal-argument':
 (defun mu4e-maildirs-extension-load ()
   "Initialize."
   (mu4e-maildirs-extension-unload)
-  (if (boundp 'mu4e-msg-changed-hook)
-      (add-hook 'mu4e-msg-changed-hook mu4e-maildirs-extension-index-updated-func)
+  (if (boundp 'mu4e-message-changed-hook)
+      (add-hook 'mu4e-message-changed-hook mu4e-maildirs-extension-index-updated-func)
   (add-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func))
   (add-hook 'mu4e-main-mode-hook mu4e-maildirs-extension-main-view-func))
 
 ;;;###autoload
 (defun mu4e-maildirs-extension-unload ()
-  "Initialize."
-  (if (boundp 'mu4e-msg-changed-hook)
-      (remove-hook 'mu4e-msg-changed-hook mu4e-maildirs-extension-index-updated-func)
+  "Un-initialize."
+  (if (boundp 'mu4e-message-changed-hook)
+      (remove-hook 'mu4e-message-changed-hook mu4e-maildirs-extension-index-updated-func)
     (remove-hook 'mu4e-index-updated-hook mu4e-maildirs-extension-index-updated-func))
   (remove-hook 'mu4e-main-mode-hook mu4e-maildirs-extension-main-view-func))
 


### PR DESCRIPTION
As per @joostkremers, `mu4e-msg-changed-hook` was renamed to
`mu4e-message-changed-hook` in mu (Cf.
https://github.com/djcb/mu/commit/600955eebca308c6bb6887051904967f4f786832).
This fixes #34.

I have also taken the liberty of editing the `unload` string. ;-)