### PR TITLE
Fix searches for maildirs with spaces in their names

### DIFF
--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -382,7 +382,7 @@ If set to `nil' it won't be displayed."
 (defun mu4e-maildirs-extension-maildir-command (path flags)
   "Quote the mu maildir command with PATH and FLAGS arguments quoted."
   (let ((query (format "%s %s"
-                       (shell-quote-argument (concat "maildir:" path))
+                       (shell-quote-argument (format "maildir:\"%s\"" path))
                        (shell-quote-argument flags))))
     (format mu4e-maildirs-extension-count-command-format query)))
 
@@ -609,7 +609,7 @@ clicked."
                 (if prefix
                     (mu4e~headers-search-execute
                      (format "%s AND flag:unread"
-                             (shell-quote-argument (concat "maildir:" maildir)))
+                             (shell-quote-argument (format "maildir:\"%s\"" maildir)))
                      nil)
                   (mu4e~headers-jump-to-maildir maildir)))))))
 


### PR DESCRIPTION
Currently, the count for any maildirs with spaces shows as 0/0. Quote
the maildir name to support spaces.