### PR TITLE
Fix reference to mu4e’s main buffer name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LOAD =  -l dash.el -l mu4e-maildirs-extension.el
 # fake mu4e package
 MU4E_FIX = --eval "(provide 'mu4e)"
 # fake `mu4e~main-buffer-name' (defined in mu4e)
-MU4E_FIX += --eval "(defvar mu4e~main-buffer-name \"tests\")"
+MU4E_FIX += --eval "(defvar mu4e-main-buffer-name \"tests\")"
 # fake `mu4e-mu-binary' (defined in mu4e)
 MU4E_FIX += --eval "(defvar mu4e-mu-binary \"mu\")"
 # lexical-let is defined in cl

--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -292,7 +292,12 @@ If set to `nil' it won't be displayed."
 
 (defvar mu4e-maildirs-extension-bookmarks nil)
 
-(defvar mu4e-maildirs-extension-buffer-name mu4e~main-buffer-name)
+(defvar mu4e-maildirs-extension-buffer-name
+  ;; mu4e~main-buffer-name used to be private API, but is now public. We
+  ;; maintain backward-compatibility with older versions.
+  (if (boundp 'mu4e~main-buffer-name)
+      mu4e~main-buffer-name
+    mu4e-main-buffer-name))
 
 (defvar mu4e-maildirs-extension-index-updated-func
   'mu4e-maildirs-extension-index-updated-handler)


### PR DESCRIPTION
In mu4e 1c1dbaf8, `mu4e~main-buffer-name` was removed and replaced with the
publically namespaced `mu4e-main-buffer-name`.

References: #52