### PR TITLE
Replace mu4e~main-action-str to mu4e--main-action-str because the function name has changed in mu4e.

### DIFF
--- a/mu4e-maildirs-extension.el
+++ b/mu4e-maildirs-extension.el
@@ -744,7 +744,7 @@ clicked."
               (insert mu4e-maildirs-extension-updating-string))
              (mu4e-maildirs-extension-action-text
               (insert "\n"
-                      (mu4e~main-action-str mu4e-maildirs-extension-action-text
+                      (mu4e--main-action-str mu4e-maildirs-extension-action-text
                                             mu4e-maildirs-extension-action-key))))
 
        (define-key mu4e-main-mode-map


### PR DESCRIPTION
In mu4e the function mu4e~main-action-str has been renamed to mu4e--main-action-str, so the function call needs to be fixed.

Signed-off-by: Ritho <palvarez@ritho.net>